### PR TITLE
Logger.emit failing, moved to process.stderr

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -40,7 +40,11 @@ module.exports.setup = function(logs) {
     } else if (target.type === 'file') {
       var dest = require('fs').createWriteStream(target.path, {flags: 'a', encoding: 'utf8'})
       dest.on('error', function (err) {
-        Logger.emit('error', err)
+        var errMsg = Object.keys(err).map(function(o) {
+          return "\t" + o + ": " + err[o];
+        }).join("\n");
+        process.stderr.write("Error logging to file: \n" + errMsg + "\n");
+        process.exit(-1);
       })
       stream.write = function(obj) {
         if (target.format === 'pretty') {


### PR DESCRIPTION
Was receiving a `TypeError: Logger.emit is not a function`, so I moved it to just using a stderr function to inform users on startup of a failure to log to file.  In response to this issue: https://github.com/rlidwka/sinopia/issues/286